### PR TITLE
Use supervisor for managing condition variables

### DIFF
--- a/lib/wait_for_it/application.ex
+++ b/lib/wait_for_it/application.ex
@@ -1,0 +1,16 @@
+defmodule WaitForIt.Application do
+  @moduledoc false
+
+  use Application
+  import Supervisor.Spec, warn: false
+
+  def start(_type, _args) do
+    children = [
+      supervisor(Registry, [:unique, WaitForIt.ConditionVariable.registry()]),
+      supervisor(WaitForIt.ConditionVariable.Supervisor, [])
+    ]
+
+    opts = [strategy: :one_for_one, name: WaitForIt.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/wait_for_it/condition_variable.ex
+++ b/lib/wait_for_it/condition_variable.ex
@@ -1,38 +1,48 @@
 defmodule WaitForIt.ConditionVariable do
   use GenServer
 
-  defstruct name: nil, waiters: []
+  defstruct waiters: []
+
+  def start_link do
+    GenServer.start_link(__MODULE__, :ok)
+  end
 
   def start_link(name) do
-    case GenServer.start_link(__MODULE__, name, name: name) do
-      {:ok, _pid} -> :ok
-      {:error, {:already_started, _pid}} -> :ok
-    end
+    GenServer.start_link(__MODULE__, :ok, name: via_tuple(name))
   end
 
-  def init(name) do
-    {:ok, %__MODULE__{name: name}}
-  end
+  def registry, do: __MODULE__.Registry
 
-  def signal(condition_var) do
-    GenServer.cast(condition_var, :signal)
-  end
+  def signal(condition_var) when is_atom(condition_var),
+    do: signal(via_tuple(condition_var))
+  def signal(condition_var),
+    do: GenServer.cast(condition_var, :signal)
 
-  def wait(condition_var, opts \\ []) do
-    GenServer.call(condition_var, :wait)
+  def wait(condition_var, opts \\ [])
+  def wait(condition_var, opts) when is_atom(condition_var),
+    do: wait(via_tuple(condition_var), opts)
+  def wait(condition_var, opts) do
+    ref = make_ref()
+    GenServer.call(condition_var, {:wait, ref})
     receive do
-      {:signal, ^condition_var} -> :ok
+      {:signal, ^ref} -> :ok
     after
       Keyword.get(opts, :timeout, 5_000) -> :timeout
     end
   end
 
-  def handle_call(:wait, {from, _tag}, state) do
-    {:reply, :ok, Map.update!(state, :waiters, &([from|&1]))}
+  def init(:ok) do
+    {:ok, %__MODULE__{}}
+  end
+
+  def handle_call({:wait, ref}, {from, _tag}, state) do
+    {:reply, :ok, Map.update!(state, :waiters, &([{from, ref}|&1]))}
   end
 
   def handle_cast(:signal, state) do
-    for pid <- state.waiters, do: send(pid, {:signal, state.name})
+    for {pid, ref} <- state.waiters, do: send(pid, {:signal, ref})
     {:noreply, %{state | waiters: []}}
   end
+
+  defp via_tuple(name), do: {:via, Registry, {registry(), name}}
 end

--- a/lib/wait_for_it/condition_variable/supervisor.ex
+++ b/lib/wait_for_it/condition_variable/supervisor.ex
@@ -1,0 +1,29 @@
+defmodule WaitForIt.ConditionVariable.Supervisor do
+  use Supervisor
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def create_condition_variable do
+    Supervisor.start_child(__MODULE__, [])
+  end
+
+  def named_condition_variable(name) when is_atom(name) do
+    case Supervisor.start_child(__MODULE__, [name]) do
+      {:ok, pid} when is_pid(pid) ->
+        {:ok, pid}
+      {:error, {:already_started, pid}} when is_pid(pid) ->
+        {:ok, pid}
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  def init(:ok) do
+    children = [
+      worker(WaitForIt.ConditionVariable, [], restart: :temporary)
+    ]
+    supervise(children, strategy: :simple_one_for_one)
+  end
+end

--- a/lib/wait_for_it/helpers.ex
+++ b/lib/wait_for_it/helpers.ex
@@ -176,7 +176,7 @@ defmodule WaitForIt.Helpers do
   end
 
   def _init_condition_var(var) do
-    :ok = ConditionVariable.start_link(var)
+    {:ok, _pid} = ConditionVariable.Supervisor.named_condition_variable(var)
   end
 
   def _start_waiter(waiting_pid, timeout) do

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,8 @@ defmodule WaitForIt.Mixfile do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {WaitForIt.Application, []}
     ]
   end
 

--- a/test/wait_for_it/condition_variable/supervisor_test.exs
+++ b/test/wait_for_it/condition_variable/supervisor_test.exs
@@ -1,0 +1,23 @@
+defmodule WaitForIt.ConditionVariable.SupervisorTest do
+  use ExUnit.Case
+  alias WaitForIt.ConditionVariable
+
+  describe "create_condition_variable/0" do
+    test "starts a new child process and returns {:ok, pid}" do
+      {:ok, pid} = ConditionVariable.Supervisor.create_condition_variable()
+      assert is_pid(pid)
+    end
+  end
+
+  describe "named_condition_variable/1" do
+    test "registers new process" do
+      {:ok, pid} = ConditionVariable.Supervisor.named_condition_variable(:new_condition_var)
+      assert [{pid, nil}] == Registry.lookup(ConditionVariable.registry(), :new_condition_var)
+    end
+
+    test "returns {:ok, pid} with existing pid if already registered" do
+      {:ok, pid} = ConditionVariable.Supervisor.named_condition_variable(:condition_var)
+      assert {:ok, ^pid} = ConditionVariable.Supervisor.named_condition_variable(:condition_var)
+    end
+  end
+end

--- a/test/wait_for_it/condition_variable_test.exs
+++ b/test/wait_for_it/condition_variable_test.exs
@@ -2,14 +2,33 @@ defmodule WaitForIt.ConditionVariableTest do
   use ExUnit.Case
   alias WaitForIt.ConditionVariable
 
+  describe "start_link/0" do
+    test "starts a new process and returns {:ok, pid}" do
+      {:ok, pid} = ConditionVariable.start_link()
+      assert is_pid(pid)
+    end
+  end
+
+  describe "start_link/1" do
+    test "registers new process" do
+      {:ok, pid} = ConditionVariable.start_link(:new_condition_var)
+      assert [{pid, nil}] == Registry.lookup(ConditionVariable.registry(), :new_condition_var)
+    end
+
+    test "returns {:error, {:already_started, pid}} if already registered" do
+      {:ok, pid} = ConditionVariable.start_link(:condition_var)
+      assert {:error, {:already_started, ^pid}} = ConditionVariable.start_link(:condition_var)
+    end
+  end
+
   test "wait blocks until signal received" do
-    :ok = ConditionVariable.start_link(:cond_wait)
+    {:ok, _pid} = ConditionVariable.start_link(:cond_wait)
     Task.async fn -> for _ <- 1..10, do: ConditionVariable.signal(:cond_wait) end
     :ok = ConditionVariable.wait(:cond_wait)
   end
 
   test "wait times out if no signal received" do
-    :ok = ConditionVariable.start_link(:cond_wait)
+    {:ok, _pid} = ConditionVariable.start_link(:cond_wait)
     :timeout = ConditionVariable.wait(:cond_wait, timeout: 10)
   end
 end


### PR DESCRIPTION
Introduce new `WaitForIt.ConditionVariable.Supervisor` module, which is a supervisor for condition variables.
Also update `WaitForIt.ConditionVariable` to use the Elixir `Registry` for process registration of condition variables.