### PR TITLE
Test on current Elixir, and diagnose the never-match warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # `mix.exs` declares `elixir: "~> 1.15"`, so 1.15 is the supported floor and
+      # the matrix spans it through the current release. The top of the range is
+      # what matters most here: Elixir's set-theoretic type checker keeps getting
+      # sharper, and a macro-heavy library is exactly where that surfaces new
+      # diagnostics — 1.20 inferring exact return types for local functions is
+      # what produced the "clause will never match" warnings this matrix now
+      # guards against.
+      #
+      # `lint: true` rides the newest entry so formatting and Credo run against
+      # current tooling rather than a version behind.
       matrix:
         include:
           - elixir: "1.15"
@@ -23,6 +33,10 @@ jobs:
             otp: "27"
           - elixir: "1.18"
             otp: "27"
+          - elixir: "1.19"
+            otp: "27"
+          - elixir: "1.20"
+            otp: "29"
             lint: true
     env:
       MIX_ENV: test
@@ -70,11 +84,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Matches `.tool-versions`, so Dialyzer analyses the same toolchain local
+      # development runs rather than trailing the test matrix by two releases.
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.18"
-          otp-version: "27"
+          elixir-version: "1.20"
+          otp-version: "29"
 
       - name: Restore deps and build cache
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Elixir 1.19 and 1.20 to the CI matrix, which now spans the declared floor (`~> 1.15`) through the
+  current release. The two most recent Elixir versions — the ones most adopters run — were
+  previously untested, and the set-theoretic type checker is exactly the kind of moving target a
+  macro-heavy library needs coverage against. The `lint` flag moved to the newest entry so
+  formatting and Credo run against current tooling, and the Dialyzer job now matches
+  `.tool-versions` instead of trailing the matrix by two releases.
+  [(Issue #23)](https://github.com/jvoegele/wait_for_it/issues/23)
+- A [Troubleshooting](guides/troubleshooting.md) guide, opening with "Why does the compiler say my
+  pattern will never match?"
+  [(Issue #24)](https://github.com/jvoegele/wait_for_it/issues/24)
+
+### Fixed
+- The test suite no longer emits "the following clause will never match" warnings on Elixir 1.20.
+  These came from the suite's own stub helpers, not from the waiting macros: 1.20 infers an exact
+  return type for a local function, so `defp pending, do: :pending` has the type `:pending`, and a
+  wait for `{:ok, _}` on it genuinely cannot match. The helpers wanted a *runtime* non-match to
+  drive the timeout paths, not a type-level one, so they now route through the process dictionary —
+  same value, no inferable type.
+
+  Characterised across waitable shapes before changing anything: the warning fires **only** when the
+  expression's inferred type is disjoint from the pattern. A union that includes the pattern, an
+  opaque value, a `@spec`'d `term()`, the `nil | struct` shape of `Repo.get/2`, and a tagged
+  `{:ok, _} | {:error, _}` union are all clean, as are `wait/2` and `case_wait/3`. So no realistic
+  waitable trips it, and when it does fire it is correct — waiting changes values over time, not
+  types, and an expression whose type cannot produce the pattern can only ever time out.
+
+  WaitForIt therefore does **not** suppress the diagnostic in its expansion. The mechanism that
+  produces the surprising warning is the same one that catches a genuinely impossible pattern in
+  user code; silencing it library-wide would trade a rare accurate warning for a permanent blind
+  spot. The guide explains the diagnosis and the fix instead.
+  [(Issue #24)](https://github.com/jvoegele/wait_for_it/issues/24)
+
 ## 2.4.0 - 2026-07-31
 ### Added
 - The `:timeout` option now accepts `:infinity`, for a wait that continues until its condition is

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ To use WaitForIt, `require WaitForIt` or `import WaitForIt`.
 
 If you are just getting started, the task-focused guides walk through the most common scenarios:
 [Waiting in tests](guides/waiting_in_tests.md), [Polling vs signaling](guides/polling_vs_signaling.md),
-[Composing waits](guides/composing_waits.md), [Recipes](guides/recipes.md), and
-[Telemetry](guides/telemetry.md).
+[Composing waits](guides/composing_waits.md), [Recipes](guides/recipes.md),
+[Telemetry](guides/telemetry.md), and [Troubleshooting](guides/troubleshooting.md).
 
 ## The five forms of waiting
 
@@ -329,6 +329,8 @@ scenarios, and read well in order:
 3. [Composing waits](guides/composing_waits.md) — chaining several waits with `with_wait/3`.
 4. [Recipes](guides/recipes.md) — ready-made patterns for databases, processes, HTTP, and more.
 5. [Telemetry](guides/telemetry.md) — observing waits in production.
+6. [Troubleshooting](guides/troubleshooting.md) — compiler diagnostics you may hit, and what they
+   mean.
 
 ## License
 

--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -1,0 +1,82 @@
+# Troubleshooting
+
+## Why does the compiler say my pattern will never match?
+
+On Elixir 1.20 and later you may see this at a `match_wait`/`with_wait` call site:
+
+```
+warning: the following clause will never match:
+
+    {:ok, _} ->
+
+because it attempts to match on the result of:
+
+    value
+
+which has type:
+
+    dynamic(:pending)
+```
+
+### What it means
+
+The waiting macros expand to a closure that evaluates the waitable expression
+once and tests the pattern against that value, re-running the closure until it
+matches or the timeout expires. Elixir's set-theoretic type checker infers a type
+for the expression and compares it to the pattern. When the two are disjoint it
+reports the clause as unreachable.
+
+**The warning is telling the truth.** It fires only when the expression's *type*
+cannot produce the pattern — not merely when its current *value* doesn't. Waiting
+changes values over time; it does not change types. If a function's return type is
+the single atom `:pending`, no amount of re-evaluation will ever make it match
+`{:ok, _}`, and the wait can only ever time out.
+
+The usual cause is a stub or helper narrow enough for the compiler to pin down
+exactly:
+
+```elixir
+defp pending, do: :pending          # inferred type: :pending
+
+with_wait on({:ok, v} <~ pending()) do   # can never match — correctly flagged
+  v
+end
+```
+
+Real waitables are rarely this narrow. A function returning `{:ok, term} | {:error, term}`,
+one whose value comes from a database or an HTTP call, or anything the checker
+cannot narrow, all admit the pattern and produce no warning.
+
+### What to do about it
+
+**If the expression really is constant**, the warning has found a bug — the wait
+cannot succeed. Fix the expression or the pattern.
+
+**If you are writing a test stub** that should fail to match at *runtime* while
+still being type-compatible, widen its return type so the checker cannot pin it
+down. Routing through the process dictionary is the simplest way, and leaves the
+returned value unchanged:
+
+```elixir
+# Before: inferred type is exactly `:pending`.
+defp pending, do: :pending
+
+# After: same value, but the checker sees `dynamic()`.
+defp pending, do: Process.get(:__unset__, :pending)
+```
+
+This library's own test suite does exactly that; see `test/wait_for_it/with_wait_test.exs`.
+
+**If the expression is genuinely dynamic** but the checker has narrowed it anyway
+— for example, it is built from literals in the same module — either add a
+`@spec` that widens the return type, or move the value behind a boundary the
+checker does not see through.
+
+### Why WaitForIt does not suppress the warning
+
+It would be possible to route the match through something opaque inside the macro
+expansion, so the diagnostic never appears. WaitForIt deliberately does not do
+this. The same mechanism that produces the spurious-looking warning above is what
+catches a genuinely impossible pattern in your own code — waiting forever for a
+shape the expression cannot return. Silencing it library-wide would trade a rare,
+accurate warning for a permanently blind spot, which is the worse deal.

--- a/mix.exs
+++ b/mix.exs
@@ -84,7 +84,8 @@ defmodule WaitForIt.Mixfile do
         "guides/polling_vs_signaling.md": [title: "Polling vs signaling"],
         "guides/composing_waits.md": [title: "Composing waits"],
         "guides/recipes.md": [title: "Recipes"],
-        "guides/telemetry.md": [title: "Telemetry"]
+        "guides/telemetry.md": [title: "Telemetry"],
+        "guides/troubleshooting.md": [title: "Troubleshooting"]
       ],
       groups_for_extras: [
         Guides: ~r{guides/.+\.md}

--- a/test/wait_for_it/test_test.exs
+++ b/test/wait_for_it/test_test.exs
@@ -18,8 +18,11 @@ defmodule WaitForIt.TestTest do
   end
 
   # Returns a value the compiler cannot constant-fold, so match/guard checks against it are not
-  # flagged as statically determinable.
-  defp never, do: :never
+  # flagged as statically determinable. Routing through the process dictionary is what makes that
+  # true under Elixir 1.20's type checker, which otherwise infers the exact return type `:never`
+  # and (correctly) reports a wait for `{:ok, _}` on it as a clause that can never match. The
+  # value returned is unchanged; the test wants a runtime non-match, not a type-level one.
+  defp never, do: Process.get(:__wait_for_it_unset__, :never)
 
   describe "assert_eventually/2 (truthy form)" do
     test "passes once the expression becomes truthy" do

--- a/test/wait_for_it/with_wait_test.exs
+++ b/test/wait_for_it/with_wait_test.exs
@@ -12,9 +12,22 @@ defmodule WaitForIt.WithWaitTest do
 
   # Wrappers that return values the compiler cannot constant-fold, so static match/guard warnings
   # are not emitted for the waiting tests.
-  defp ok(value), do: {:ok, value}
-  defp err(reason), do: {:error, reason}
-  defp pending, do: :pending
+  #
+  # `opaque/1` is what makes that true. Elixir 1.20's type checker infers a return
+  # type for a local function, so `defp pending, do: :pending` has the exact type
+  # `:pending` — and a wait for `{:ok, _}` on it is then, correctly, a clause that
+  # can never match. These helpers want a *runtime* non-match to drive the timeout
+  # paths, not a type-level one, so they route through the process dictionary,
+  # which the checker cannot narrow. The value returned is unchanged.
+  #
+  # This is a fix to the fixtures, not a workaround for a library bug: see the
+  # "Why does the compiler say my pattern will never match?" section of the
+  # troubleshooting guide.
+  defp opaque(value), do: Process.get(:__wait_for_it_unset__, value)
+
+  defp ok(value), do: opaque({:ok, value})
+  defp err(reason), do: opaque({:error, reason})
+  defp pending, do: opaque(:pending)
 
   # Returns {:ok, n} once the counter reaches `threshold`, otherwise :pending.
   defp ready_at(threshold) do


### PR DESCRIPTION
Addresses #23 and #24, which turn out to be one piece of work: the matrix topped out at 1.18, so the warnings #24 is about were invisible to the pipeline that should have caught them.

## Characterisation first (#24)

On the pinned toolchain (1.20.0 / OTP 29), `mix test` emits **8** "the following clause will never match" warnings across `with_wait_test.exs` and `test_test.exs`.

Before changing anything, I built the matrix of waitable shapes the issue asked for, since it called the blast radius "unbounded until we characterize it":

| shape | result |
|---|---|
| helper returning a single atom (the test-helper shape) | **WARNS** |
| inline literal atom | **WARNS** |
| union that includes the pattern | clean |
| opaque (`Process.get` with a default) | clean |
| `@spec`'d `term()` | clean |
| `nil \| term` (the `Repo.get/2` shape) | clean |
| tagged `{:ok, _} \| {:error, _}` union (HTTP shape) | clean |
| bare `wait/2` on a narrow helper | clean |
| `case_wait` on a narrow helper | clean |

It fires **only when the expression's inferred type is disjoint from the pattern**, and no realistic waitable is that narrow.

More to the point: **when it fires, it's correct.** Waiting changes values over time, not types. An expression whose type cannot produce the pattern can only ever time out, so the warning is finding a real bug rather than misunderstanding the library. The premise in the issue — that the checker "has no way to know the expression is re-evaluated" — is true but doesn't rescue these cases, because re-evaluation can't widen a type.

## Disposition

That settles it, and **option 2 is declined** with the reasoning recorded in the guide and CHANGELOG. Routing the match through something opaque inside the expansion would make the diagnostic disappear — and would also blind the checker to a genuinely impossible pattern in user code. That trades a rare accurate warning for a permanent blind spot, which is the worse deal, and is the risk the issue itself flags.

## What changed instead

**The suite's own stub helpers (option 4).** Their comments already claimed the compiler "cannot constant-fold" them — true when written, not on 1.20, which infers an exact return type for a local function. They want a *runtime* non-match to drive the timeout paths, not a type-level one, so they now route through the process dictionary: same value, no inferable type. **8 warnings → 0**, 84 tests still pass.

**A [Troubleshooting](guides/troubleshooting.md) guide (option 3)** opening with "Why does the compiler say my pattern will never match?" — what it means, why it's accurate, how to widen a stub, and why the library doesn't suppress it. Linked from the README guide list and added to the ExDoc extras. (`guides` was already in the Hex package `files:`, so no repeat of external_service#42.)

**The CI matrix (#23).** Added 1.19/OTP 27 and 1.20/OTP 29, so it spans the declared floor (`~> 1.15`) through the current release. `lint: true` moved to the newest entry so formatting and Credo run against current tooling, and the Dialyzer job now matches `.tool-versions` rather than trailing the matrix by two releases. Verified locally on 1.20 that `format --check-formatted`, `compile --warnings-as-errors`, `credo --strict`, and `dialyzer` all pass.

## One thing I could not settle locally

Whether **1.19** also warns. Installing Hex for the older toolchains failed on a TLS error in this environment, so 1.20 is the only version I measured directly — the issue assumed 1.19/1.20 and I can only vouch for 1.20. The matrix now answers it on every push, which is rather the point of #23.

## Not in scope

The remaining `mix test` warning noise is ~26 v1 deprecation warnings from the legacy test file. That's #27's territory and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
