### PR TITLE
Trim the caller's Macro.Env out of telemetry metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,33 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   pattern will never match?"
   [(Issue #24)](https://github.com/jvoegele/wait_for_it/issues/24)
 
+### Changed
+- **Telemetry metadata `env` is now a trimmed map rather than the caller's whole `Macro.Env`**
+  ([Issue #22](https://github.com/jvoegele/wait_for_it/issues/22)). It carries exactly
+  `:context`, `:context_modules`, `:file`, `:function`, `:line`, and `:module` — the same six
+  fields `WaitForIt.TimeoutError` has always exposed. The two paths disagreed about what `env`
+  meant; now they share one definition and cannot drift apart again.
+
+  A full `__ENV__` measured **1019 words (~8 KB)** in a module with ordinary imports, of which
+  most is the calling module's import table (`:functions`, `:macros`, `:requires`) — it grows
+  with the caller's imports and is of no use to a handler. That term was embedded in the
+  caller's compiled module once per wait, copied into the signal registry's ETS on every
+  signal-based wait, and copied again by every handler that forwarded metadata off-process.
+
+  The trim happens at **macro expansion**, so the fat term is never emitted rather than being
+  discarded later. Measured on a module with three wait sites:
+
+  | | before | after |
+  |---|---|---|
+  | `env` term | 1019 words | 29 words |
+  | whole event metadata | 1039 words | 49 words |
+  | caller's compiled beam | 12,612 bytes | 3,360 bytes |
+
+  A handler reading anything outside those six keys needs updating; one reading `env.file` or
+  `env.line` does not. The value passed down internally stays a real `%Macro.Env{}` so that
+  `Macro.Env.stacktrace/1` still reraises a timed-out `match_wait`/`case_wait`/`cond_wait` at
+  the caller's location — byte-for-byte the stacktrace it produced before.
+
 ### Fixed
 - The test suite no longer emits "the following clause will never match" warnings on Elixir 1.20.
   These came from the suite's own stub helpers, not from the waiting macros: 1.20 infers an exact

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -33,6 +33,42 @@ timeout is **not** an exception: it is reported as a `:stop` event with `result:
 - **Measurements:** `%{duration}`
 - **Metadata:** `%{wait_type, wait_context, timeout, interval, signal, env, kind, reason, stacktrace}`
 
+## The `env` metadata
+
+Every event carries `env`, the source location of the wait — a plain map with
+exactly these keys:
+
+| key | |
+|---|---|
+| `:module` | the module containing the wait |
+| `:function` | `{name, arity}`, or `nil` at module level |
+| `:file` | absolute path |
+| `:line` | line of the wait |
+| `:context` | `:match`, `:guard`, or `nil` |
+| `:context_modules` | modules being defined at that point |
+
+It is enough to attribute an event to a call site, which is what a handler needs
+it for:
+
+```elixir
+def handle_event([:wait_for_it, :wait, :stop], meas, %{env: env} = meta, _) do
+  Logger.info("#{meta.result} at #{env.file}:#{env.line} after #{meas.duration}")
+end
+```
+
+> #### This used to be the caller's whole `Macro.Env` {: .info}
+>
+> Before 2.5.0, `env` was the untrimmed `__ENV__` — roughly 1000 words (~8 KB),
+> almost all of it the calling module's import table (`:functions`, `:macros`,
+> `:requires`), which grows with the caller's imports and is of no use to a
+> handler. It was embedded in the caller's compiled module once per wait and
+> copied by every handler that forwarded metadata off-process.
+>
+> A handler reading anything outside the six keys above needs updating; one
+> reading `env.file`/`env.line` does not. The same six fields have always been
+> what `WaitForIt.TimeoutError` exposes — the telemetry path simply never applied
+> the same cut.
+
 ## Wait context
 
 `wait_type` names the *form* of waiting that ran, which is not always the form you wrote. A `<~`

--- a/lib/wait_for_it.ex
+++ b/lib/wait_for_it.ex
@@ -90,7 +90,7 @@ defmodule WaitForIt do
       require WaitForIt.Waitable.BasicWait
 
       waitable = WaitForIt.Waitable.BasicWait.create(unquote(expression))
-      WaitForIt.Waiting.wait(waitable, unquote(opts), __ENV__)
+      WaitForIt.Waiting.wait(waitable, unquote(opts), unquote(WaitForIt.Env.escaped(__CALLER__)))
     end
   end
 
@@ -103,7 +103,7 @@ defmodule WaitForIt do
       require WaitForIt.Waitable.BasicWait
 
       waitable = WaitForIt.Waitable.BasicWait.create(unquote(expression))
-      WaitForIt.Waiting.wait!(waitable, unquote(opts), __ENV__)
+      WaitForIt.Waiting.wait!(waitable, unquote(opts), unquote(WaitForIt.Env.escaped(__CALLER__)))
     end
   end
 
@@ -210,7 +210,7 @@ defmodule WaitForIt do
           unquote(else_block)
         )
 
-      WaitForIt.Waiting.wait(waitable, unquote(opts), __ENV__)
+      WaitForIt.Waiting.wait(waitable, unquote(opts), unquote(WaitForIt.Env.escaped(__CALLER__)))
     end
   end
 
@@ -232,7 +232,7 @@ defmodule WaitForIt do
           unquote(else_block)
         )
 
-      WaitForIt.Waiting.wait!(waitable, unquote(opts), __ENV__)
+      WaitForIt.Waiting.wait!(waitable, unquote(opts), unquote(WaitForIt.Env.escaped(__CALLER__)))
     end
   end
 
@@ -304,7 +304,7 @@ defmodule WaitForIt do
           unquote(else_block)
         )
 
-      WaitForIt.Waiting.wait(waitable, unquote(opts), __ENV__)
+      WaitForIt.Waiting.wait(waitable, unquote(opts), unquote(WaitForIt.Env.escaped(__CALLER__)))
     end
   end
 
@@ -325,7 +325,7 @@ defmodule WaitForIt do
           unquote(else_block)
         )
 
-      WaitForIt.Waiting.wait!(waitable, unquote(opts), __ENV__)
+      WaitForIt.Waiting.wait!(waitable, unquote(opts), unquote(WaitForIt.Env.escaped(__CALLER__)))
     end
   end
 
@@ -374,7 +374,7 @@ defmodule WaitForIt do
       require WaitForIt.Waitable.MatchWait
 
       waitable = WaitForIt.Waitable.MatchWait.create(unquote(pattern), unquote(expression))
-      WaitForIt.Waiting.wait(waitable, unquote(opts), __ENV__)
+      WaitForIt.Waiting.wait(waitable, unquote(opts), unquote(WaitForIt.Env.escaped(__CALLER__)))
     end
   end
 
@@ -387,7 +387,7 @@ defmodule WaitForIt do
       require WaitForIt.Waitable.MatchWait
 
       waitable = WaitForIt.Waitable.MatchWait.create(unquote(pattern), unquote(expression))
-      WaitForIt.Waiting.wait!(waitable, unquote(opts), __ENV__)
+      WaitForIt.Waiting.wait!(waitable, unquote(opts), unquote(WaitForIt.Env.escaped(__CALLER__)))
     end
   end
 
@@ -466,7 +466,7 @@ defmodule WaitForIt do
       waitable =
         WaitForIt.Waitable.MatchWait.create(unquote(match_pattern), unquote(expression))
 
-      WaitForIt.Waiting.wait(waitable, unquote(opts), __ENV__)
+      WaitForIt.Waiting.wait(waitable, unquote(opts), unquote(WaitForIt.Env.escaped(__CALLER__)))
     end
   end
 

--- a/lib/wait_for_it/env.ex
+++ b/lib/wait_for_it/env.ex
@@ -1,0 +1,60 @@
+defmodule WaitForIt.Env do
+  @moduledoc false
+
+  # The caller's `Macro.Env`, cut down to the fields anything downstream actually
+  # reads.
+  #
+  # A full `__ENV__` is around 1000 words (~8 KB), and almost all of it is the
+  # calling module's import table — `:functions`, `:macros`, `:requires` — which
+  # grows with the caller's imports and is of no use to a telemetry handler or an
+  # error struct. That term was being embedded in the caller's compiled module
+  # once per wait, copied into the signal registry's ETS on every signal-based
+  # wait, and copied again by any telemetry handler that forwards metadata
+  # off-process.
+  #
+  # Trimming happens at macro expansion rather than at runtime, so the fat term is
+  # never emitted in the first place: `escaped/1` is what the waiting macros
+  # unquote in place of `__ENV__`.
+  #
+  # The trimmed value stays a real `%Macro.Env{}` rather than becoming a plain map,
+  # because `Macro.Env.stacktrace/1` is called on it when a timeout reraises a
+  # `MatchError`/`CaseClauseError`/`CondClauseError` at the caller's location. It
+  # reads only `:module`, `:function`, `:file`, and `:line`, all of which survive,
+  # so the reraised stacktrace is byte-for-byte what it was before.
+
+  # The fields worth keeping. `WaitForIt.TimeoutError` has exposed exactly this set
+  # since it was written; the telemetry path simply never applied the same cut.
+  @kept [:context, :context_modules, :file, :function, :line, :module]
+
+  @doc """
+  Returns `env` with everything but `#{inspect(@kept)}` reset to the `Macro.Env`
+  defaults.
+  """
+  @spec trim(Macro.Env.t()) :: Macro.Env.t()
+  def trim(%Macro.Env{} = env), do: struct(Macro.Env, Map.take(env, @kept))
+
+  @doc """
+  Returns the trimmed env as quoted AST, for a macro to unquote in place of
+  `__ENV__`.
+  """
+  @spec escaped(Macro.Env.t()) :: Macro.t()
+  def escaped(%Macro.Env{} = env), do: env |> trim() |> Macro.escape()
+
+  @doc """
+  Returns the plain-map form carried in telemetry metadata and on
+  `WaitForIt.TimeoutError`.
+
+  A map rather than a struct because it is data crossing a boundary — into a
+  telemetry handler, a log line, or a serialized error — where a `Macro.Env`
+  struct would invite the assumption that the rest of its fields are populated.
+  """
+  @spec to_map(Macro.Env.t() | nil) :: map() | nil
+  def to_map(%Macro.Env{} = env), do: Map.take(env, @kept)
+  def to_map(_other), do: nil
+
+  @doc """
+  The env fields WaitForIt retains.
+  """
+  @spec kept_fields() :: [atom()]
+  def kept_fields, do: @kept
+end

--- a/lib/wait_for_it/timeout_error.ex
+++ b/lib/wait_for_it/timeout_error.ex
@@ -53,11 +53,9 @@ defmodule WaitForIt.TimeoutError do
     struct(__MODULE__, params)
   end
 
+  # Delegates so that this and the telemetry metadata cannot drift apart about what
+  # `env` means — they disagreed before, with telemetry carrying the untrimmed term.
   @doc false
-  @spec make_env(Macro.Env.t()) :: env()
-  def make_env(%Macro.Env{} = env),
-    do: Map.take(env, [:context, :context_modules, :file, :function, :line, :module])
-
-  @spec make_env(any()) :: nil
-  def make_env(_), do: nil
+  @spec make_env(Macro.Env.t() | nil) :: env() | nil
+  defdelegate make_env(env), to: WaitForIt.Env, as: :to_map
 end

--- a/lib/wait_for_it/waiting.ex
+++ b/lib/wait_for_it/waiting.ex
@@ -208,7 +208,7 @@ defmodule WaitForIt.Waiting do
       timeout: wait_opts[:timeout],
       interval: wait_opts[:interval],
       signal: wait_opts[:signal],
-      env: env
+      env: WaitForIt.Env.to_map(env)
     }
   end
 

--- a/test/wait_for_it/env_test.exs
+++ b/test/wait_for_it/env_test.exs
@@ -1,0 +1,192 @@
+defmodule WaitForIt.EnvTest do
+  @moduledoc """
+  Tests for the trimmed `env` that waits carry (issue #22).
+
+  A full `__ENV__` is around 1000 words, almost all of it the calling module's
+  import table, and it was being embedded in the caller's compiled module once
+  per wait, copied into the signal registry, and copied again by every telemetry
+  handler that forwarded metadata off-process.
+
+  Trimming happens at macro expansion, so the fat term is never emitted. The
+  value stays a real `%Macro.Env{}` where it is passed down, because
+  `Macro.Env.stacktrace/1` is called on it to reraise at the caller's location.
+  """
+
+  use ExUnit.Case, async: false
+
+  import WaitForIt
+
+  @kept [:context, :context_modules, :file, :function, :line, :module]
+
+  def relay(event, measurements, metadata, pid),
+    do: send(pid, {:telemetry, event, measurements, metadata})
+
+  defp attach do
+    handler = "env-test-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler,
+      [[:wait_for_it, :wait, :start], [:wait_for_it, :wait, :stop]],
+      &__MODULE__.relay/4,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+  end
+
+  describe "telemetry metadata env" do
+    setup do
+      attach()
+      :ok
+    end
+
+    test "carries exactly the retained fields" do
+      wait(true, timeout: 50)
+
+      assert_received {:telemetry, [:wait_for_it, :wait, :stop], _meas, meta}
+      assert meta.env |> Map.keys() |> Enum.sort() == @kept
+    end
+
+    test "is a plain map, not a Macro.Env struct" do
+      # It is data crossing a boundary; a struct would imply the other fields are
+      # populated.
+      wait(true, timeout: 50)
+
+      assert_received {:telemetry, [:wait_for_it, :wait, :stop], _meas, meta}
+      assert is_map(meta.env)
+      refute is_struct(meta.env)
+    end
+
+    test "points at this call site" do
+      line = __ENV__.line + 1
+      wait(true, timeout: 50)
+
+      assert_received {:telemetry, [:wait_for_it, :wait, :stop], _meas, meta}
+      assert meta.env.module == __MODULE__
+      assert meta.env.line == line
+      assert meta.env.file == __ENV__.file
+      assert {name, _arity} = meta.env.function
+      assert is_atom(name)
+    end
+
+    test "does not carry the caller's import table" do
+      # The regression this exists for: `:functions`, `:macros`, and `:requires`
+      # are the bulk of a full env and are of no use to a handler.
+      wait(true, timeout: 50)
+
+      assert_received {:telemetry, [:wait_for_it, :wait, :stop], _meas, meta}
+
+      refute Map.has_key?(meta.env, :functions)
+      refute Map.has_key?(meta.env, :macros)
+      refute Map.has_key?(meta.env, :requires)
+      refute Map.has_key?(meta.env, :aliases)
+      refute Map.has_key?(meta.env, :lexical_tracker)
+      refute Map.has_key?(meta.env, :versioned_vars)
+    end
+
+    test "is a small fraction of a full env in the same module" do
+      # Calibrated against this module's own `__ENV__` rather than an absolute
+      # word count, so the assertion stays meaningful as the module's imports
+      # change. A full env here is on the order of 1000 words.
+      wait(true, timeout: 50)
+
+      assert_received {:telemetry, [:wait_for_it, :wait, :stop], _meas, meta}
+
+      full = :erts_debug.flat_size(__ENV__)
+      trimmed = :erts_debug.flat_size(meta.env)
+
+      assert trimmed * 10 < full, "expected #{trimmed} words to be <1/10th of #{full}"
+    end
+
+    test "the start event carries the same env as the stop event" do
+      wait(true, timeout: 50)
+
+      assert_received {:telemetry, [:wait_for_it, :wait, :start], _meas, start_meta}
+      assert_received {:telemetry, [:wait_for_it, :wait, :stop], _meas, stop_meta}
+      assert start_meta.env == stop_meta.env
+    end
+  end
+
+  describe "TimeoutError env agrees with telemetry" do
+    test "both carry the same shape and the same values" do
+      attach()
+
+      error =
+        try do
+          wait!(false, timeout: 20, interval: 1)
+        rescue
+          e in WaitForIt.TimeoutError -> e
+        end
+
+      assert_received {:telemetry, [:wait_for_it, :wait, :stop], _meas, meta}
+
+      # The two paths disagreed before: TimeoutError trimmed, telemetry did not.
+      assert error.env == meta.env
+      assert error.env |> Map.keys() |> Enum.sort() == @kept
+    end
+  end
+
+  # Opaque to the type checker: returns `:never` at runtime, but Elixir 1.20 would
+  # otherwise infer the exact type `:never` and flag the wait pattern as a clause
+  # that can never match. See the Troubleshooting guide.
+  defp never, do: Process.get(:__wait_for_it_unset__, :never)
+
+  defp timing_out_match_wait do
+    match_wait({:ok, _v}, never(), timeout: 20, interval: 1, on_timeout: :raise_last_value)
+  end
+
+  describe "reraise still points at the caller" do
+    test "a match_wait timeout raises MatchError at the call site" do
+      # `Macro.Env.stacktrace/1` is called on the trimmed env for this. It reads
+      # only module/function/file/line, all of which survive the trim.
+      {error, stacktrace} =
+        try do
+          timing_out_match_wait()
+          flunk("expected a MatchError")
+        rescue
+          e in MatchError -> {e, __STACKTRACE__}
+        end
+
+      assert %MatchError{} = error
+      assert [{__MODULE__, :timing_out_match_wait, _arity, location} | _] = stacktrace
+      assert location[:line] == match_wait_source_line()
+      assert to_string(location[:file]) =~ "env_test.exs"
+    end
+  end
+
+  # Found by scanning the source rather than recorded as an offset from a module
+  # attribute, which drifts the moment the formatter reflows anything above it.
+  defp match_wait_source_line do
+    index =
+      __ENV__.file
+      |> File.read!()
+      |> String.split("\n")
+      |> Enum.find_index(&String.contains?(&1, "match_wait({:ok, _v}, never()"))
+
+    index + 1
+  end
+
+  describe "WaitForIt.Env" do
+    test "trim/1 keeps a real Macro.Env so stacktrace/1 still works" do
+      full = __ENV__
+      trimmed = WaitForIt.Env.trim(full)
+
+      assert %Macro.Env{} = trimmed
+      assert Macro.Env.stacktrace(trimmed) == Macro.Env.stacktrace(full)
+    end
+
+    test "trim/1 drops the bulky fields" do
+      trimmed = WaitForIt.Env.trim(__ENV__)
+
+      assert trimmed.functions == []
+      assert trimmed.macros == []
+      assert trimmed.requires == []
+      assert :erts_debug.flat_size(trimmed) < :erts_debug.flat_size(__ENV__)
+    end
+
+    test "to_map/1 returns nil for a non-env" do
+      assert WaitForIt.Env.to_map(nil) == nil
+      assert WaitForIt.Env.to_map(:nope) == nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #22.

Confirmed your measurement exactly — and the ratio is the sharper framing: the env was **1019 of the 1039 words** of event metadata, so ~98% of every telemetry event was the caller's import table.

## Three costs, not one

The issue names two; there's a third. The term was:

1. embedded in the caller's compiled module, once per wait site;
2. **copied into the signal registry's ETS on every signal-based wait** — `Registry.register(SignalRegistry, signal, env)` stores it as the registry value;
3. copied again by any handler that forwards metadata off-process.

## Took option 2

Trim at macro expansion rather than at runtime, so the fat term is never emitted rather than built and discarded. The nine `__ENV__` sites in the macros now unquote a trimmed literal built from `__CALLER__`. Measured on a module with three wait sites and ordinary imports:

| | before | after |
|---|---|---|
| `env` term | 1019 words | **29 words** |
| whole event metadata | 1039 words | **49 words** |
| caller's compiled beam | 12,612 bytes | **3,360 bytes** |

## One constraint the issue doesn't mention

`env` isn't only telemetry and `TimeoutError`. `case_wait`, `cond_wait`, and `match_wait` call `Macro.Env.stacktrace(env)` to reraise a timeout at the caller's location — so trimming to a plain map would have broken those reraises.

The value passed down therefore stays a real `%Macro.Env{}`, with only the bulky fields reset to their struct defaults. `Macro.Env.stacktrace/1` reads just module/function/file/line, all of which survive, so the reraised stacktrace is byte-for-byte what it was. Verified directly:

```
stacktrace(full):    [{User, :run, 0, [file: ~c".../probe.exs", line: 22]}]
stacktrace(trimmed): [{User, :run, 0, [file: ~c".../probe.exs", line: 22]}]
equal? true
```

and pinned by a test that asserts the reraised frame's line against the source line it should point at.

## The two paths now share one definition

Telemetry metadata gets the plain-map form — the same six fields `TimeoutError.make_env/1` has always produced. Both route through the new `WaitForIt.Env`, and `make_env/1` is now a delegate, so they cannot drift apart again. That was the underlying complaint: the two disagreed about what `env` meant.

## Visible change

A handler reading anything outside `:context`, `:context_modules`, `:file`, `:function`, `:line`, `:module` needs updating; one reading `env.file`/`env.line` does not. The CHANGELOG says so, and `guides/telemetry.md` — which documented `env` without saying what was in it (option 3) — now has a field table and a note on what changed.

## Tests

95, up from 84. The 11 new cover the retained field set, that the import table is gone, that it's a plain map rather than a struct, that it points at the call site, that start and stop agree, that `TimeoutError` and telemetry now carry identical values, that a timed-out `match_wait` still reraises at the caller's line, and `WaitForIt.Env` itself.

Warning output, `mix format`, `credo --strict`, and `dialyzer` are all unchanged from `master`.

One small thing worth noting: my first draft of the reraise test used `match_wait({:ok, _v}, :never, ...)`, which promptly tripped the "clause will never match" warning from #24 — the literal atom is exactly the narrow shape that diagnostic catches. The fixture now goes through an opaque helper, per the Troubleshooting guide added in #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
